### PR TITLE
test: downgrade rest-assured since the update to 4.5.0 is causing T2A…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
-            <version>4.5.0</version>
+            <version>4.4.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Downgrade rest-assured since the update to 4.5.0 is causing T2ARouteBuilderTestCase not to run properly